### PR TITLE
Gracefully uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ $ cf copyenv APP_NAME > temp.json
 $ source temp.json
 ```
 
+You can obtain additional information with flags.
+```
+$ cf copyenv APP_NAME -all
+
+export VCAP_SERVICES='...'
+export VCAP_APPLICATION='...'
+```
+
+
 ## Uninstall
 
 ```

--- a/copyenv.go
+++ b/copyenv.go
@@ -69,6 +69,9 @@ func (c *CopyEnv) ExportCredsAsShellVar(creds string) {
 }
 
 func (c *CopyEnv) Run(cliConnection plugin.CliConnection, args []string) {
+	if len(args) > 0 && args[0] == "CLI-MESSAGE-UNINSTALL" {
+		return
+	}
 	app_name, err := c.ExtractAppName(args)
 	fatalIf(err)
 

--- a/copyenv_test.go
+++ b/copyenv_test.go
@@ -37,18 +37,18 @@ var _ = Describe("Cloud Foundry Copyenv Command", func() {
 		})
 
 		It("Return Service Credentials From Appplication Environment", func() {
-			_, err := callCopyEnvCommandPlugin.ExtractServiceCredentialsJSON([]string{""})
+			_, err := callCopyEnvCommandPlugin.ExtractCredentialsJSON("VCAP_SERVICES", []string{""})
 			Ω(err).Should(MatchError("missing service credentials for application"))
 
 			service_creds := []string{"{\"VCAP_SERVICES\":{\"service\": [ { \"credentials\": {} } ]}}"}
-			b, err := callCopyEnvCommandPlugin.ExtractServiceCredentialsJSON(service_creds)
+			b, err := callCopyEnvCommandPlugin.ExtractCredentialsJSON("VCAP_SERVICES", service_creds)
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(b[:])).Should(Equal("{\"service\":[{\"credentials\":{}}]}"))
 		})
 
 		It("Print Service Credentials As Shell Variable", func() {
 			output := io_helpers.CaptureOutput(func() {
-				callCopyEnvCommandPlugin.ExportCredsAsShellVar("testing")
+				callCopyEnvCommandPlugin.ExportCredsAsShellVar("VCAP_SERVICES", "testing")
 			})
 			Ω(output[0]).Should(Equal("export VCAP_SERVICES='testing';"))
 		})

--- a/copyenv_test.go
+++ b/copyenv_test.go
@@ -52,5 +52,10 @@ var _ = Describe("Cloud Foundry Copyenv Command", func() {
 			})
 			Ω(output[0]).Should(Equal("export VCAP_SERVICES='testing';"))
 		})
+
+		It("Silently uninstalls", func() {
+			callCopyEnvCommandPlugin.Run(fakeCliConnection, []string{"CLI-MESSAGE-UNINSTALL"})
+			Ω(fakeCliConnection.CliCommandWithoutTerminalOutputCallCount()).Should(Equal(0))
+		})
 	})
 })

--- a/copyenv_test.go
+++ b/copyenv_test.go
@@ -57,5 +57,26 @@ var _ = Describe("Cloud Foundry Copyenv Command", func() {
 			callCopyEnvCommandPlugin.Run(fakeCliConnection, []string{"CLI-MESSAGE-UNINSTALL"})
 			Ω(fakeCliConnection.CliCommandWithoutTerminalOutputCallCount()).Should(Equal(0))
 		})
+
+		Context("when called with --all", func() {
+			It("Extracts VCAP_APPLICATION and VCAP_SERVICE", func() {
+				services := "{\"VCAP_SERVICES\":[\"services\"]}"
+				application := "{\"VCAP_APPLICATION\":[\"application\"]}"
+				fakeCliConnection.CliCommandWithoutTerminalOutputReturns([]string{
+					services, application, "OTHER"}, nil)
+
+				output := io_helpers.CaptureOutput(func() {
+					callCopyEnvCommandPlugin.Run(fakeCliConnection, []string{"copyenv", "APP_NAME", "--all"})
+				})
+
+				Ω(output).Should(ContainElement(
+					"export VCAP_APPLICATION='[\"application\"]';",
+				))
+
+				Ω(output).Should(ContainElement(
+					"export VCAP_SERVICES='[\"services\"]';",
+				))
+			})
+		})
 	})
 })


### PR DESCRIPTION
Fix the plugin trying to extract an app name when being invoked for an uninstall by the cf cli.

Current output:

```
$ cf uninstall-plugin copyenv
Uninstalling plugin copyenv...
FAILED
Plugin name copyenv does not exist
Sams-MacBook-Pro:copyenv sam$ cf install-plugin copyenv

Installing plugin ./copyenv...
OK
Plugin copyenv v1.0.0 successfully installed.
```

New output:

```
$ cf uninstall-plugin copyenv
Uninstalling plugin copyenv...
OK
Plugin copyenv successfully uninstalled.
```
