### PR TITLE
Updating code to compile using current versions of the cloud foundry cli api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Using eval:
 $ eval `cf copyenv APP_NAME` 
 ```
 
+Using command substitution: 
+```
+$ $(cf copyenv APP_NAME)` 
+```
+
 Using a temporary file:
 ```
 $ cf copyenv APP_NAME > temp.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ eval `cf copyenv APP_NAME`
 
 Using command substitution: 
 ```
-$ $(cf copyenv APP_NAME)` 
+$ $(cf copyenv APP_NAME)
 ```
 
 Using a temporary file:


### PR DESCRIPTION
The primary change was to get it to compile using the latest cloud foundry cli with the new "proxied" hostname, refactoring, and changed CF env layout. 
See new import path [here](https://github.com/cloudfoundry/cli/blob/master/plugin/pluginfakes/fake_cli_connection.go).

Cleaned up some of the linting type complaints such as removing "_" from variable names, and making the non public methods use lower case.

I updated the osx build as well.